### PR TITLE
Refresh token rotation

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/oauth/OAuth2TokenServices.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/OAuth2TokenServices.java
@@ -186,6 +186,12 @@ public class OAuth2TokenServices
             throw new InvalidGrantException("Wrong client for this refresh token: " + refreshTokenValue);
         }
 
+        // check request has offline_access scope
+        Set<String> scopes = authentication.getOAuth2Request().getScope();
+        if (!scopes.contains(Config.SCOPE_OFFLINE_ACCESS)) {
+            throw new InvalidRequestException("refresh requires offline_access scope");
+        }
+
         // fetch client
         OAuth2ClientDetails clientDetails = clientDetailsService.loadClientByClientId(clientId);
 

--- a/src/main/java/it/smartcommunitylab/aac/oauth/OAuth2TokenServices.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/OAuth2TokenServices.java
@@ -235,6 +235,12 @@ public class OAuth2TokenServices
 
             }
 
+            // check if client has rotate to always configured
+            if (clientDetails.isRefreshTokenRotation()) {
+                // renew regardless of expiration
+                renewToken = true;
+            }
+
             // build a new oauthAuthentication matching tokenRequest
             OAuth2Authentication refreshedAuthentication = refreshAuthentication(authentication, tokenRequest);
 
@@ -254,6 +260,7 @@ public class OAuth2TokenServices
             accessToken.setRefreshToken(refreshToken);
 
             // if needed build a new refresh token and replace in response
+            // TODO keep old refresh token valid for a small window to account delays
             if (renewToken) {
                 // if we renew use the original authentication, not the refreshed
                 OAuth2RefreshToken refreshedToken = createRefreshToken(authentication, refreshValiditySeconds);

--- a/src/main/java/it/smartcommunitylab/aac/oauth/auth/ClientBasicAuthFilter.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/auth/ClientBasicAuthFilter.java
@@ -164,6 +164,16 @@ public class ClientBasicAuthFilter extends AbstractAuthenticationProcessingFilte
                 authRequest = new OAuth2ClientPKCEAuthenticationToken(clientId, code, verifier,
                         AuthenticationMethod.NONE.getValue());
             }
+
+            // support refresh flow with pkce without secret
+            // requires refresh token rotation set
+            if ("refresh_token".equals(grantType)
+                    && request.getParameterMap().containsKey("refresh_token")) {
+                String refreshToken = request.getParameter("refresh_token");
+                // replace request
+                authRequest = new OAuth2ClientRefreshAuthenticationToken(clientId, refreshToken,
+                        AuthenticationMethod.NONE.getValue());
+            }
         }
 
         // collect request details

--- a/src/main/java/it/smartcommunitylab/aac/oauth/auth/ClientFormAuthTokenEndpointFilter.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/auth/ClientFormAuthTokenEndpointFilter.java
@@ -124,6 +124,16 @@ public class ClientFormAuthTokenEndpointFilter extends AbstractAuthenticationPro
                 authRequest = new OAuth2ClientPKCEAuthenticationToken(clientId, code, verifier,
                         AuthenticationMethod.NONE.getValue());
             }
+
+            // support refresh flow with pkce without secret
+            // requires refresh token rotation set
+            if ("refresh_token".equals(grantType)
+                    && request.getParameterMap().containsKey("refresh_token")) {
+                String refreshToken = request.getParameter("refresh_token");
+                // replace request
+                authRequest = new OAuth2ClientRefreshAuthenticationToken(clientId, refreshToken,
+                        AuthenticationMethod.NONE.getValue());
+            }
         }
 
         // collect request details

--- a/src/main/java/it/smartcommunitylab/aac/oauth/auth/OAuth2ClientRefreshAuthenticationProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/auth/OAuth2ClientRefreshAuthenticationProvider.java
@@ -1,0 +1,180 @@
+package it.smartcommunitylab.aac.oauth.auth;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidGrantException;
+import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+import org.springframework.security.oauth2.provider.ClientRegistrationException;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.ParseException;
+
+import it.smartcommunitylab.aac.core.auth.ClientAuthenticationProvider;
+import it.smartcommunitylab.aac.core.auth.UserAuthentication;
+import it.smartcommunitylab.aac.Config;
+import it.smartcommunitylab.aac.common.NoSuchClientException;
+import it.smartcommunitylab.aac.core.ClientDetails;
+import it.smartcommunitylab.aac.core.auth.ClientAuthentication;
+import it.smartcommunitylab.aac.oauth.model.OAuth2ClientDetails;
+import it.smartcommunitylab.aac.oauth.service.OAuth2ClientDetailsService;
+import it.smartcommunitylab.aac.oauth.store.ExtTokenStore;
+
+public class OAuth2ClientRefreshAuthenticationProvider extends ClientAuthenticationProvider
+        implements InitializingBean {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final OAuth2ClientDetailsService clientDetailsService;
+
+    // we need to peek at token store to load original auth
+    private final ExtTokenStore tokenStore;
+
+    public OAuth2ClientRefreshAuthenticationProvider(
+            OAuth2ClientDetailsService clientDetailsService,
+            ExtTokenStore tokenStore) {
+        Assert.notNull(tokenStore, "token store is required");
+        Assert.notNull(clientDetailsService, "client details service is required");
+        this.clientDetailsService = clientDetailsService;
+        this.tokenStore = tokenStore;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Assert.notNull(clientService, "client service is required");
+    }
+
+    @Override
+    public ClientAuthentication authenticate(Authentication authentication) throws AuthenticationException {
+        Assert.isInstanceOf(OAuth2ClientRefreshAuthenticationToken.class, authentication,
+                "Only OAuth2ClientRefreshAuthenticationToken is supported");
+
+        OAuth2ClientRefreshAuthenticationToken authRequest = (OAuth2ClientRefreshAuthenticationToken) authentication;
+        String clientId = authRequest.getPrincipal();
+        String refreshTokenValue = authRequest.getRefreshToken();
+        String authenticationMethod = authRequest.getAuthenticationMethod();
+
+        if (!StringUtils.hasText(clientId) || !StringUtils.hasText(refreshTokenValue)) {
+            throw new BadCredentialsException("missing required parameters in request");
+        }
+
+        try {
+            // load details, we need to check request
+            OAuth2ClientDetails client = clientDetailsService.loadClientByClientId(clientId);
+
+            // check if client can authenticate with this scheme
+            if (!client.getAuthenticationMethods().contains(authenticationMethod)) {
+                this.logger.debug("Failed to authenticate since client can not use scheme " + authenticationMethod);
+                throw new BadCredentialsException("invalid authentication");
+            }
+
+            /*
+             * We authenticate clients by checking if refresh token rotation is set and if
+             * the original authentication used the same method
+             */
+            if (!client.isRefreshTokenRotation()) {
+                this.logger.debug("Failed to authenticate since client has token rotation disabled");
+                throw new BadCredentialsException("invalid authentication");
+            }
+
+            OAuth2RefreshToken refreshToken = tokenStore.readRefreshToken(refreshTokenValue);
+            if (refreshToken == null) {
+                throw new InvalidGrantException("Invalid refresh token: " + refreshTokenValue);
+            }
+
+            OAuth2Authentication oauth = tokenStore.readAuthenticationForRefreshToken(refreshToken);
+            if (oauth == null) {
+                // don't leak
+                throw new BadCredentialsException("invalid request");
+            }
+
+            // check if userAuth is present
+            Authentication userAuth = oauth.getUserAuthentication();
+            if (userAuth == null || !(userAuth instanceof UserAuthentication)) {
+                throw new InvalidRequestException("refresh requires a valid user authentication");
+            }
+
+            OAuth2Request oauth2Request = oauth.getOAuth2Request();
+
+            if (!oauth2Request.getClientId().equals(clientId)) {
+                // client id does not match
+                throw new BadCredentialsException("invalid request");
+            }
+
+            // check request has offline_access scope
+            Set<String> scopes = oauth2Request.getScope();
+            if (!scopes.contains(Config.SCOPE_OFFLINE_ACCESS)) {
+                throw new InvalidRequestException("refresh requires offline_access scope");
+            }
+
+            // check request was auth_code
+            GrantType grantType = null;
+            try {
+                grantType = GrantType.parse(oauth2Request.getGrantType());
+            } catch (ParseException e) {
+                // invalid grant type, should not happen here
+                throw new InvalidRequestException("invalid token");
+
+            }
+
+            if (!GrantType.AUTHORIZATION_CODE.equals(grantType)) {
+                throw new InvalidRequestException("refresh requires auth_code grant ype as origin");
+            }
+
+            // check auth method is PKCE
+            // TODO evaluate skipping this check
+            String codeChallenge = oauth2Request.getRequestParameters().get(PkceParameterNames.CODE_CHALLENGE);
+            String codeChallengeMethod = oauth2Request.getRequestParameters()
+                    .get(PkceParameterNames.CODE_CHALLENGE_METHOD);
+
+            // we need to be sure this is a PKCE request
+            if (!StringUtils.hasText(codeChallenge) || !StringUtils.hasText(codeChallengeMethod)) {
+                // this is NOT a PKCE authcode
+                throw new BadCredentialsException("invalid request");
+            }
+
+            // load authorities from clientService
+            Collection<GrantedAuthority> authorities;
+            try {
+                ClientDetails clientDetails = clientService.loadClient(clientId);
+                authorities = clientDetails.getAuthorities();
+            } catch (NoSuchClientException e) {
+                throw new ClientRegistrationException("invalid client");
+            }
+
+            // result contains credentials, someone later on will need to call
+            // eraseCredentials
+            OAuth2ClientRefreshAuthenticationToken result = new OAuth2ClientRefreshAuthenticationToken(clientId,
+                    refreshTokenValue,
+                    authenticationMethod, authorities);
+
+            // save details
+            // TODO add ClientDetails in addition to oauth2ClientDetails
+            result.setOAuth2ClientDetails(client);
+            result.setWebAuthenticationDetails(authRequest.getWebAuthenticationDetails());
+
+            return result;
+        } catch (ClientRegistrationException e) {
+            throw new BadCredentialsException("invalid authentication");
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return (OAuth2ClientRefreshAuthenticationToken.class.isAssignableFrom(authentication));
+    }
+
+}

--- a/src/main/java/it/smartcommunitylab/aac/oauth/auth/OAuth2ClientRefreshAuthenticationToken.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/auth/OAuth2ClientRefreshAuthenticationToken.java
@@ -1,0 +1,50 @@
+package it.smartcommunitylab.aac.oauth.auth;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import it.smartcommunitylab.aac.SystemKeys;
+
+/*
+ * A usernamePassword auth token to be used for clientId+verifier auth
+ */
+
+public class OAuth2ClientRefreshAuthenticationToken extends OAuth2ClientAuthenticationToken {
+
+    private static final long serialVersionUID = SystemKeys.AAC_OAUTH2_SERIAL_VERSION;
+
+    private String refreshToken;
+
+    public OAuth2ClientRefreshAuthenticationToken(String clientId, String refreshToken,
+            String authenticationMethod) {
+        super(clientId);
+        this.refreshToken = refreshToken;
+        this.authenticationMethod = authenticationMethod;
+        setAuthenticated(false);
+    }
+
+    public OAuth2ClientRefreshAuthenticationToken(String clientId, String refreshToken,
+            String authenticationMethod,
+            Collection<? extends GrantedAuthority> authorities) {
+        super(clientId, authorities);
+        this.refreshToken = refreshToken;
+        this.authenticationMethod = authenticationMethod;
+
+    }
+
+    @Override
+    public String getCredentials() {
+        return this.refreshToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    @Override
+    public void eraseCredentials() {
+        super.eraseCredentials();
+        this.refreshToken = null;
+    }
+
+}

--- a/src/main/java/it/smartcommunitylab/aac/oauth/client/OAuth2Client.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/client/OAuth2Client.java
@@ -437,7 +437,7 @@ public class OAuth2Client extends BaseClient implements ConfigurableProperties {
 //        }
 //        c.jwksUri = oauth.getJwksUri();
 
-        Map<String, String> additionalInfo = oauth.getAdditionalInformation();
+        Map<String, Serializable> additionalInfo = oauth.getAdditionalInformation();
         if (additionalInfo != null) {
             c.configMap.setAdditionalInformation(OAuth2ClientInfo.convert(additionalInfo));
 //            c.additionalInformation = OAuth2ClientInfo.convert(map);

--- a/src/main/java/it/smartcommunitylab/aac/oauth/client/OAuth2ClientAdditionalConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/client/OAuth2ClientAdditionalConfig.java
@@ -49,6 +49,10 @@ public class OAuth2ClientAdditionalConfig implements Serializable {
     @JsonProperty("id_token_encrypted_response_enc")
     private EncryptionMethod idTokenEncMethod;
 
+    // refresh token config
+    @JsonProperty("refresh_token_rotation")
+    private Boolean refreshTokenRotation;
+
     // userinfo jwt config
     @JsonProperty("userinfo_signed_response_alg")
     private JWSAlgorithm userinfoSignAlgorithm;
@@ -235,6 +239,14 @@ public class OAuth2ClientAdditionalConfig implements Serializable {
 
     public void setRequestUris(Set<String> requestUris) {
         this.requestUris = requestUris;
+    }
+
+    public Boolean getRefreshTokenRotation() {
+        return refreshTokenRotation;
+    }
+
+    public void setRefreshTokenRotation(Boolean refreshTokenRotation) {
+        this.refreshTokenRotation = refreshTokenRotation;
     }
 
 }

--- a/src/main/java/it/smartcommunitylab/aac/oauth/client/OAuth2ClientConfigMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/client/OAuth2ClientConfigMap.java
@@ -147,6 +147,16 @@ public class OAuth2ClientConfigMap implements ConfigurableProperties, Serializab
         this.firstParty = firstParty;
     }
 
+    public boolean isRefreshTokenRotation() {
+        if (additionalConfig == null) {
+            return false;
+        }
+
+        return additionalConfig.getRefreshTokenRotation() != null
+                ? additionalConfig.getRefreshTokenRotation().booleanValue()
+                : false;
+    }
+
     public Integer getAccessTokenValidity() {
         return accessTokenValidity;
     }
@@ -239,11 +249,14 @@ public class OAuth2ClientConfigMap implements ConfigurableProperties, Serializab
         this.jwksUri = map.getJwksUri();
 
         // handle additional props
-        if (map.getAdditionalConfig() != null) {
-            this.additionalConfig = map.getAdditionalConfig();
+        // we parse again the map because we flatten props by unwrapping
+        OAuth2ClientAdditionalConfig additionalConfig = OAuth2ClientAdditionalConfig.convert(props);
+        if (additionalConfig != null) {
+            this.additionalConfig = additionalConfig;
         }
-        if (map.getAdditionalInformation() != null) {
-            this.additionalInformation = map.getAdditionalInformation();
+        OAuth2ClientInfo clientInfo = OAuth2ClientInfo.convert(props);
+        if (clientInfo != null) {
+            this.additionalInformation = clientInfo;
         }
 //        if(props != null && props.containsKey("additionalInformation")) {
 //            this.additionalInformation = OAuth2ClientInfo.convert(props.get("additionalInformation"));

--- a/src/main/java/it/smartcommunitylab/aac/oauth/client/OAuth2ClientInfo.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/client/OAuth2ClientInfo.java
@@ -36,7 +36,7 @@ public class OAuth2ClientInfo implements Serializable {
 //    }
 
     @SuppressWarnings("unchecked")
-    public static Map<String, String> read(String additionalInformation) {
+    public static Map<String, Serializable> read(String additionalInformation) {
         try {
             return mapper.readValue(additionalInformation, Map.class);
         } catch (JsonProcessingException e) {
@@ -44,7 +44,7 @@ public class OAuth2ClientInfo implements Serializable {
         }
     }
 
-    public static OAuth2ClientInfo convert(Map<String, String> map) {
+    public static OAuth2ClientInfo convert(Map<String, Serializable> map) {
         return mapper.convertValue(map, OAuth2ClientInfo.class);
     }
 
@@ -58,7 +58,7 @@ public class OAuth2ClientInfo implements Serializable {
     }
 
     @SuppressWarnings("unchecked")
-    public Map<String, String> toMap() throws IllegalArgumentException {
+    public Map<String, Serializable> toMap() throws IllegalArgumentException {
         try {
             mapper.setSerializationInclusion(Include.NON_EMPTY);
             return mapper.convertValue(this, HashMap.class);

--- a/src/main/java/it/smartcommunitylab/aac/oauth/model/OAuth2ClientDetails.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/model/OAuth2ClientDetails.java
@@ -131,6 +131,9 @@ public class OAuth2ClientDetails implements ClientDetails {
     private boolean firstParty = false;
 
     @JsonIgnore
+    private boolean refreshTokenRotation = false;
+
+    @JsonIgnore
     private Map<String, Object> additionalInformation = new LinkedHashMap<String, Object>();
 
     // hooks
@@ -324,6 +327,14 @@ public class OAuth2ClientDetails implements ClientDetails {
 
     public void setFirstParty(boolean firstParty) {
         this.firstParty = firstParty;
+    }
+
+    public boolean isRefreshTokenRotation() {
+        return refreshTokenRotation;
+    }
+
+    public void setRefreshTokenRotation(boolean refreshTokenRotation) {
+        this.refreshTokenRotation = refreshTokenRotation;
     }
 
     public Set<String> getResponseTypes() {

--- a/src/main/java/it/smartcommunitylab/aac/oauth/persistence/OAuth2ClientEntity.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/persistence/OAuth2ClientEntity.java
@@ -74,7 +74,7 @@ public class OAuth2ClientEntity {
     private String tokenType;
 
     @Column(name = "id_token_claims")
-    private boolean idTokenClaims = false;
+    private Boolean idTokenClaims;
 
     /*
      * OAuth2 flows - related info
@@ -107,14 +107,14 @@ public class OAuth2ClientEntity {
     @Lob
     @Column(name = "additional_information")
     @Convert(converter = HashMapConverter.class)
-    private Map<String, String> additionalInformation;
+    private Map<String, Serializable> additionalInformation;
 
     /*
      * first party clients won't require approval for in-realm resource consumption
      * (realm idp, realm identity, realm service etc) matching a list of scopes
      */
     @Column(name = "first_party")
-    private boolean firstParty = false;
+    private Boolean firstParty;
 
     // TODO drop resourceids (which exist only in resource server) in favor of
     // audience which indicates the resource servers
@@ -249,27 +249,35 @@ public class OAuth2ClientEntity {
         this.additionalConfiguration = additionalConfiguration;
     }
 
-    public Map<String, String> getAdditionalInformation() {
+    public Map<String, Serializable> getAdditionalInformation() {
         return additionalInformation;
     }
 
-    public void setAdditionalInformation(Map<String, String> additionalInformation) {
+    public void setAdditionalInformation(Map<String, Serializable> additionalInformation) {
         this.additionalInformation = additionalInformation;
     }
 
     public boolean isFirstParty() {
+        return firstParty != null ? firstParty.booleanValue() : false;
+    }
+
+    public Boolean getFirstParty() {
         return firstParty;
     }
 
-    public void setFirstParty(boolean firstParty) {
+    public void setFirstParty(Boolean firstParty) {
         this.firstParty = firstParty;
     }
 
     public boolean isIdTokenClaims() {
+        return idTokenClaims != null ? idTokenClaims.booleanValue() : false;
+    }
+
+    public Boolean getIdTokenClaims() {
         return idTokenClaims;
     }
 
-    public void setIdTokenClaims(boolean idTokenClaims) {
+    public void setIdTokenClaims(Boolean idTokenClaims) {
         this.idTokenClaims = idTokenClaims;
     }
 

--- a/src/main/java/it/smartcommunitylab/aac/oauth/service/OAuth2ClientDetailsService.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/service/OAuth2ClientDetailsService.java
@@ -99,6 +99,11 @@ public class OAuth2ClientDetailsService implements ClientDetailsService {
                     clientDetails.setJwtEncAlgorithm(config.getJwtEncMethod().getValue());
                 }
 
+                boolean isRefreshTokenRotation = config.getRefreshTokenRotation() != null
+                        ? config.getRefreshTokenRotation().booleanValue()
+                        : false;
+                clientDetails.setRefreshTokenRotation(isRefreshTokenRotation);
+
             } catch (Exception e) {
                 // ignore additional config
             }

--- a/src/main/resources/public/html/app/conf.oauth2.html
+++ b/src/main/resources/public/html/app/conf.oauth2.html
@@ -112,6 +112,13 @@
                     <label>IdToken custom claims</label>
                 </div>
             </div>
+            <div class="form-group col">
+                <div class="form-check form-check-inline"
+                    ng-click="app.configuration.refresh_token_rotation = !app.configuration.refresh_token_rotation">
+                    <input class="form-check-input" type="checkbox" ng-model="app.configuration.refresh_token_rotation">
+                    <label>Refresh token rotation</label>
+                </div>
+            </div>            
         </div>
 
         <div class="row">


### PR DESCRIPTION
Add refresh token rotation and support requesting refresh via token endpoint without using a client secret.

Supports the following flow:
1. enable refresh token rotation for client
1. request an access_token with `offline_access` scope via `authorization_code` and PKCE
1. obtain a refresh token bound to PKCE auth
1. refresh access token via refresh token request without secret