### PR TITLE
fix #335: change converter priority to permit client_secret_post authentication

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/oauth/auth/OAuth2ClientAuthFilter.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/auth/OAuth2ClientAuthFilter.java
@@ -56,8 +56,8 @@ public class OAuth2ClientAuthFilter extends OncePerRequestFilter {
                 new ClientJwtAssertionAuthenticationConverter(),
                 new ClientPKCEAuthenticationConverter(),
                 new ClientRefreshAuthenticationConverter(),
-                new ClientSecretBasicAuthenticationConverter(),
-                new ClientSecretPostAuthenticationConverter());
+                new ClientSecretPostAuthenticationConverter(),
+                new ClientSecretBasicAuthenticationConverter());
 
         // build request matcher
         requestMatcher = new AntPathRequestMatcher(filterProcessingUrl);


### PR DESCRIPTION
invert priority between client secret post authentication converter and client secret basic authentication converter, to prevent exception thrown in method :
`public OAuth2ClientSecretAuthenticationToken attemptConvert(HttpServletRequest request) {`
`    try {`
`        Pair<String, Optional<String>> basicAuth = extractBasicAuth(request);`
`        if (basicAuth == null) {`
`            throw new OAuth2AuthenticationException(new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST));`
`        }`
of class ClientSecretBasicAuthenticationConverter.

client_id and client_secret authentication is an allowed method and should not thrown INVALID_REQUEST exception.
