### PR TITLE
fix #335: update client secret basic auth converter to not throw exception when attempting conversion

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/oauth/auth/ClientSecretBasicAuthenticationConverter.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/auth/ClientSecretBasicAuthenticationConverter.java
@@ -26,7 +26,7 @@ public class ClientSecretBasicAuthenticationConverter extends OAuth2ClientAuthen
         try {
             Pair<String, Optional<String>> basicAuth = extractBasicAuth(request);
             if (basicAuth == null) {
-                throw new OAuth2AuthenticationException(new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST));
+                return null;
             }
 
             String clientId = basicAuth.getFirst();


### PR DESCRIPTION
When attempting conversion, ClientSecretBasicAuthenticationConverter should not throw an exception when no Authorization header is found, but should return null so that the next Authentication Converter (ClientSecretPostAuthenticationConverter) can attempt the conversion