### PR TITLE
fix #330: SuperAdmin can now assign roles/authorities to client applications

### DIFF
--- a/src/main/resources/public/js/realmapps.js
+++ b/src/main/resources/public/js/realmapps.js
@@ -409,8 +409,9 @@ angular.module('aac.controllers.realmapps', [])
         var slug = $stateParams.realmId;
         var clientId = $stateParams.clientId;
 
-        $scope.isRealmAdmin = $rootScope.user.authorities.some(a => (a.realm === slug && a.role === 'ROLE_ADMIN'));
-        $scope.isRealmDev = $scope.isRealmAdmin || $rootScope.user.authorities.some(a => (a.realm === slug && a.role === 'ROLE_DEVELOPER'));
+        $scope.isAdmin = $rootScope.user.authorities.some(a => (a.authority === 'ROLE_ADMIN'));
+        $scope.isRealmAdmin = $scope.isAdmin || $rootScope.user.authorities.some(a => (a.realm === slug && a.role === 'ROLE_ADMIN'));
+        $scope.isRealmDev = $scope.isAdmin || $scope.isRealmAdmin || $rootScope.user.authorities.some(a => (a.realm === slug && a.role === 'ROLE_DEVELOPER'));
 
         $scope.clientView = 'overview';
 


### PR DESCRIPTION
fixed SuperAdmin capability to assign roles/authorities to client applications