### PR TITLE
fix #209: audit timestamp visualization has been restored

### DIFF
--- a/src/main/resources/public/html/app/audit.html
+++ b/src/main/resources/public/html/app/audit.html
@@ -16,7 +16,7 @@
                     </tr>
                 </thead>
                 <tr ng-repeat="item in audit">
-                    <td class="align-middle">{{item.timestamp.epochSecond * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</td>
+                    <td class="align-middle">{{item.timestamp * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</td>
                     <td class="align-middle">{{item.type | uppercase}}</td>
                     <td class="align-middle">
                         <div ng-if="item.type == 'CLIENT_AUTHENTICATION_SUCCESS' && item.data.details" class="text-secondary">

--- a/src/main/resources/public/html/realm.audit.html
+++ b/src/main/resources/public/html/realm.audit.html
@@ -50,7 +50,7 @@
                 </tr>
             </thead>
             <tr ng-repeat="item in events">
-                <td class="align-middle">{{item.timestamp.epochSecond * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</td>
+                <td class="align-middle">{{item.timestamp * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</td>
                 <td class="align-middle">{{item.type | uppercase}}</td>
                 <td class="align-middle">{{item.principal}}</td>
                 <td class="text-right">
@@ -75,7 +75,7 @@
             </div>
             <div class="modal-body" id="modal-body">
                 <h6>Timestamp</h6>
-                <p>{{modEvent.timestamp.epochSecond * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</p>
+                <p>{{modEvent.timestamp * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</p>
                 
                 <h6>Event type</h6>                
                 <p>{{modEvent.type | uppercase}}</p>

--- a/src/main/resources/public/html/realm.audit.html
+++ b/src/main/resources/public/html/realm.audit.html
@@ -32,6 +32,7 @@
                     <div class="form-group col">
                         <button class="btn btn-primary" type="button" ng-click="reload()">Search</button>
                     </div>
+                </div>
             </form>
         </div>
     </div>

--- a/src/main/resources/public/html/realm.dashboard.html
+++ b/src/main/resources/public/html/realm.dashboard.html
@@ -230,7 +230,7 @@
                         <p ng-if="!stats.loginEvents || stats.loginEvents.length == 0"> No events</p>
                         <table class="table" ng-if="stats.loginEvents && stats.loginEvents.length > 0">
                            <tr ng-repeat="item in stats.loginEvents">
-                              <td class="align-middle">{{item.timestamp.epochSecond * 1000 | date:'yyyy-MM-dd HH:mm'}}
+                              <td class="align-middle">{{item.timestamp * 1000 | date:'yyyy-MM-dd HH:mm'}}
                               </td>
                               <td class="align-middle">{{item.principal}}</td>
                            </tr>
@@ -248,7 +248,7 @@
                         <p ng-if="!stats.registrationEvents || stats.registrationEvents.length == 0"> No events</p>
                         <table class="table" ng-if="stats.registrationEvents && stats.registrationEvents.length > 0">
                            <tr ng-repeat="item in stats.registrationEvents">
-                              <td class="align-middle">{{item.timestamp.epochSecond * 1000 | date:'yyyy-MM-dd HH:mm'}}
+                              <td class="align-middle">{{item.timestamp * 1000 | date:'yyyy-MM-dd HH:mm'}}
                               </td>
                               <td class="align-middle">{{item.principal}}</td>
                            </tr>

--- a/src/main/resources/public/html/user/audit.html
+++ b/src/main/resources/public/html/user/audit.html
@@ -16,7 +16,7 @@
                     </tr>
                 </thead>
                 <tr ng-repeat="item in audit">
-                    <td class="align-middle">{{item.timestamp.epochSecond * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</td>
+                    <td class="align-middle">{{item.timestamp * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</td>
                     <td class="align-middle">{{item.type | uppercase}}</td>
                     <td class="align-middle">
                         <div ng-if="item.type == 'USER_AUTHENTICATION_SUCCESS' && item.data.details" class="text-secondary">


### PR DESCRIPTION
fixed audit timestamp conversion which was preventing the display of the "Time" field in the Audit and Dashboard pages and in the User and Client Audit tabs