### PR TITLE
fix endsession URL, the previous was not reachable

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/openid/endpoint/EndSessionEndpoint.java
+++ b/src/main/java/it/smartcommunitylab/aac/openid/endpoint/EndSessionEndpoint.java
@@ -202,7 +202,7 @@ public class EndSessionEndpoint {
     }
 
     @Hidden
-    @RequestMapping(value = END_SESSION_URL, method = RequestMethod.POST)
+    @RequestMapping(value = END_SESSION_CONFIRM_URL, method = RequestMethod.POST)
     public void processLogout(
         @RequestParam(value = "approve", required = false) Optional<String> approve,
         HttpServletRequest request,


### PR DESCRIPTION
according to #378 the hidden URL must be END_SESSION_CONFIRM_URL, however in #395 have overridden the method in END_SESSION_URL.
That fix the problem establishing the correct URL END_SESSION_CONFIRM_URL