### PR TITLE
fix #451 console can save and load attribute providers settings

### DIFF
--- a/src/main/resources/public/html/provider/ap.attributesets.html
+++ b/src/main/resources/public/html/provider/ap.attributesets.html
@@ -4,7 +4,7 @@
        <legend class="mb-4">Attribute Sets</legend>
        <div ng-if="attributeSets && attributeSets.length > 0">
            <table class="table table-hover border-bottom">
-               <tr ng-repeat="item in attributeSets" class="{{ap.attributeSets.includes(item.identifier) ? '' : 'text-muted'}}">
+               <tr ng-repeat="item in attributeSets" class="{{ap.settings.attributeSets.includes(item.identifier) ? '' : 'text-muted'}}">
                    <td class="align-middle">
                        <span class="h6">{{item.name}}</span> <br>
                        <small class="text-muted"> {{item.identifier }}</small>
@@ -13,7 +13,7 @@
                    <td class="text-right">
                      <div class="toggles">
                          <label>
-                             <input type="checkbox" ng-checked="ap.attributeSets.includes(item.identifier)" ng-click="toggleProviderAttributeSet(item)">
+                             <input type="checkbox" ng-checked="ap.settings.attributeSets.includes(item.identifier)" ng-click="toggleProviderAttributeSet(item)">
                              <span class="lever"></span>
                          </label>
                      </div>                      

--- a/src/main/resources/public/html/provider/ap.settings.html
+++ b/src/main/resources/public/html/provider/ap.settings.html
@@ -14,22 +14,22 @@
             <div class="form-group col ">
                 <div class="bootstrap-select-wrapper border-bottom-0">
                     <label for="persistence">Persistence*</label>
-                    <select id="persistence" ng-model="ap.persistence">
-                        <option value="none" ng-selected="ap.persistence=='none'">None</option>
-                        <option value="session" ng-selected="ap.persistence=='session'">Session</option>
-                        <option value="memory" ng-selected="ap.persistence=='memory'">Memory</option>
-                        <option value="repository" ng-selected="ap.persistence=='repository'">Repository</option>
+                    <select id="persistence" ng-model="ap.settings.persistence">
+                        <option value="none" ng-selected="ap.settings.persistence=='none'">None</option>
+                        <option value="session" ng-selected="ap.settings.persistence=='session'">Session</option>
+                        <option value="memory" ng-selected="ap.settings.persistence=='memory'">Memory</option>
+                        <option value="repository" ng-selected="ap.settings.persistence=='repository'">Repository</option>
                     </select>
                 </div>
             </div>
             <div class="form-group col ">
                 <div class="bootstrap-select-wrapper border-bottom-0">
                     <label for="events">Audit events*</label>
-                    <select id="events" ng-model="ap.events">
-                        <option value="none" ng-selected="ap.events=='none'">None</option>
-                        <option value="minimal" ng-selected="ap.events=='minimal'">Minimal</option>
-                        <option value="details" ng-selected="ap.events=='details'">Details</option>
-                        <option value="full" ng-selected="ap.events=='full'">Full</option>
+                    <select id="events" ng-model="ap.settings.events">
+                        <option value="none" ng-selected="ap.settings.events=='none'">None</option>
+                        <option value="minimal" ng-selected="ap.settings.events=='minimal'">Minimal</option>
+                        <option value="details" ng-selected="ap.settings.events=='details'">Details</option>
+                        <option value="full" ng-selected="ap.settings.events=='full'">Full</option>
                     </select>
                 </div>
             </div>          

--- a/src/main/resources/public/js/realmproviders.js
+++ b/src/main/resources/public/js/realmproviders.js
@@ -1174,10 +1174,9 @@ angular.module('aac.controllers.realmproviders', [])
                 name: provider.name,
                 description: provider.description,
                 enabled: provider.enabled,
-                persistence: provider.persistence,
-                events: provider.events,
-                attributeSets: provider.attributeSets,
+                settings: provider.settings,
                 configuration: configuration
+
             }
 
             RealmProviders.saveAttributeProvider($scope.realm.slug, data)
@@ -1206,16 +1205,19 @@ angular.module('aac.controllers.realmproviders', [])
         }
 
         $scope.toggleProviderAttributeSet = function (attributeSet) {
+            if(!$scope.ap.settings.attributeSets){
+                $scope.ap.settings.attributeSets = [];
+            }
             if (attributeSet.identifier) {
                 var id = attributeSet.identifier;
-                var setIds = $scope.ap.attributeSets;
-                if ($scope.ap.attributeSets.includes(id)) {
+                var setIds = $scope.ap.settings.attributeSets;
+                if ($scope.ap.settings.attributeSets.includes(id)) {
                     setIds = setIds.filter(i => id != i);
                 } else {
                     setIds.push(id);
                 }
 
-                $scope.ap.attributeSets = setIds;
+                $scope.ap.settings.attributeSets = setIds;
 
             }
         }


### PR DESCRIPTION
console can now save and load attribute providers settings (audit, persistence, attribute sets)