### PR TITLE
Bugfix SAML new accounts

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAuthenticationProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAuthenticationProvider.java
@@ -53,7 +53,7 @@ public class SamlAuthenticationProvider
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static final String SUBJECT_ATTRIBUTE = "subject";
-
+    private static final int MAX_PRINCIPALID_LENGTH = 128;
     private final UserAccountService<SamlUserAccount> accountService;
     private final SamlIdentityProviderConfig config;
     private final String repositoryId;
@@ -204,17 +204,30 @@ public class SamlAuthenticationProvider
         return authentication != null && Saml2AuthenticationToken.class.isAssignableFrom(authentication);
     }
 
+    private String evaluateSubjectId(Saml2AuthenticatedPrincipal samlDetails, String subjectAttributeKey) throws Exception {
+        var targetAttributeValue = samlDetails.getFirstAttribute(subjectAttributeKey);
+        if (targetAttributeValue == null) {
+            String availableAttributes = "[" + String.join(",", samlDetails.getAttributes().keySet()) + "]";
+            String errorMessage = String.format("unable to fetch attribute %s from a principal with the following attributes: %s", subjectAttributeKey, availableAttributes);
+            throw new Exception(errorMessage);
+        }
+        String subject = targetAttributeValue.toString();
+        if (!(StringUtils.hasText(subject))) {
+            String errorMessage = String.format("attribute with name %s is either associated to a null value, is empty, or hash only whitespaces", subjectAttributeKey);
+            throw new Exception(errorMessage);
+        }
+        if ((subject.length() > MAX_PRINCIPALID_LENGTH)) {
+            String errorMessage = String.format("attribute with name %s and value %s (length %d) has a length exceeding maximum allowed length %d", subjectAttributeKey, subject, subject.length(), MAX_PRINCIPALID_LENGTH);
+            throw new Exception(errorMessage);
+        }
+        return subject;
+    }
+
     @Override
     protected SamlUserAuthenticatedPrincipal createUserPrincipal(Object principal) {
         // we need to unpack token and fetch properties from repo
         // note we expect default behavior, if provider has a converter this will break
         Saml2AuthenticatedPrincipal samlDetails = (Saml2AuthenticatedPrincipal) principal;
-
-        // upstream subject identifier
-        //        String subjectId = StringUtils.hasText(samlDetails.getFirstAttribute(SUBJECT_ATTRIBUTE))
-        //                ? samlDetails.getFirstAttribute(SUBJECT_ATTRIBUTE)
-        //                : samlDetails.getName();
-        String subjectId = samlDetails.getName();
 
         // name is always available, by default is subjectId
         String name = samlDetails.getName();
@@ -226,6 +239,18 @@ public class SamlAuthenticationProvider
 
         // we still don't have userId
         String userId = null;
+
+        // subjectId is optionally evaluated from an attribute defined in provider configurations
+        String subjectId = samlDetails.getName();
+        String subAttributeName = config.getConfigMap().getSubAttributeName();
+        if (StringUtils.hasText(subAttributeName)) {
+            try {
+                subjectId = evaluateSubjectId(samlDetails, subAttributeName);
+            } catch (Exception exc) {
+                logger.error("Failed to evaluate or obtain the principalId in the the Saml2AuthenticatedPrincipal - the following error wa obtained: " + exc.getMessage());
+                return null; // fail authentication
+            }
+        }
 
         // bind principal to ourselves
         SamlUserAuthenticatedPrincipal user = new SamlUserAuthenticatedPrincipal(

--- a/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAuthenticationProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAuthenticationProvider.java
@@ -215,7 +215,9 @@ public class SamlAuthenticationProvider
         Saml2AuthenticatedPrincipal samlDetails = (Saml2AuthenticatedPrincipal) principal;
 
         // subjectId is optionally evaluated from an attribute defined in saml provider configurations
-        String subjectId = StringUtils.hasText(subAttributeName) ? samlDetails.getFirstAttribute(subAttributeName) : samlDetails.getName();
+        String subjectId = StringUtils.hasText(subAttributeName)
+            ? samlDetails.getFirstAttribute(subAttributeName)
+            : samlDetails.getName();
         if (subjectId == null) {
             logger.error("Failed to evaluate or obtain the subjectId in the the Saml2AuthenticatedPrincipal");
             return null; // fail authentication
@@ -231,7 +233,6 @@ public class SamlAuthenticationProvider
 
         // we still don't have userId
         String userId = null;
-
 
         // bind principal to ourselves
         SamlUserAuthenticatedPrincipal user = new SamlUserAuthenticatedPrincipal(

--- a/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlIdentityProviderConfig.java
@@ -229,6 +229,11 @@ public class SamlIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return configMap.getRequireEmailAddress() != null ? configMap.getRequireEmailAddress().booleanValue() : false;
     }
 
+    public String getSubAttributeName() {
+        String subAttributeName = configMap.getSubAttributeName();
+        return StringUtils.hasText(subAttributeName) ? subAttributeName : null;
+    }
+
     //
     private Saml2X509Credential getVerificationCertificate(String certificate)
         throws CertificateException, IOException {

--- a/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlIdentityProviderConfigMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlIdentityProviderConfigMap.java
@@ -72,6 +72,8 @@ public class SamlIdentityProviderConfigMap extends AbstractConfigMap implements 
     private Boolean alwaysTrustEmailAddress;
     private Boolean requireEmailAddress;
 
+    private String subAttributeName;
+
     public SamlIdentityProviderConfigMap() {}
 
     public String getSigningKey() {
@@ -250,6 +252,15 @@ public class SamlIdentityProviderConfigMap extends AbstractConfigMap implements 
         this.requireEmailAddress = requireEmailAddress;
     }
 
+    public String getSubAttributeName() {
+        return subAttributeName;
+    }
+
+    public void setSubAttributeName(String subAttributeName) {
+        this.subAttributeName = subAttributeName;
+    }
+
+
     @JsonIgnore
     public void setConfiguration(SamlIdentityProviderConfigMap map) {
         this.signingKey = map.getSigningKey();
@@ -279,6 +290,7 @@ public class SamlIdentityProviderConfigMap extends AbstractConfigMap implements 
         this.requireEmailAddress = map.getRequireEmailAddress();
 
         this.entityId = map.getEntityId();
+        this.subAttributeName = map.getSubAttributeName();
     }
 
     @Override

--- a/src/main/resources/public/html/provider/idp.conf.saml.html
+++ b/src/main/resources/public/html/provider/idp.conf.saml.html
@@ -165,5 +165,12 @@
 
         </div>
 
+        <div class="row">
+            <div class="form-group col">
+                <label for="subAttributeName">SAML attribute used as subject id</label>
+                <textarea rows="1" id="subAttributeName" name="subAttributeName"
+                          ng-model="idp.configuration.subAttributeName"></textarea>
+            </div>
+        </div>
     </fieldset>
 </div>


### PR DESCRIPTION
This is a proposal resolution for issue #311 .
Added option to use the value in a custom SAML attribute as subject identifier when performing a SAML authentication.
The default behaviour (still supported when no attribute is choosen) uses a nonce/random value obtained from the SAML and will result in a new account at each user athentication.