### PR TITLE
claims family_name is overwritten only if surname exists

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAttributeProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAttributeProvider.java
@@ -104,7 +104,7 @@ public class SamlAttributeProvider
 
         // override from account
         map.put(OpenIdAttributesSet.NAME, name);
-        if (surname != null) {
+        if (StringUtils.hasText(surname)) {
             map.put(OpenIdAttributesSet.FAMILY_NAME, surname);
         }
         map.put(OpenIdAttributesSet.EMAIL, email);

--- a/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAttributeProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAttributeProvider.java
@@ -104,7 +104,9 @@ public class SamlAttributeProvider
 
         // override from account
         map.put(OpenIdAttributesSet.NAME, name);
-        map.put(OpenIdAttributesSet.FAMILY_NAME, surname);
+        if (surname != null) {
+            map.put(OpenIdAttributesSet.FAMILY_NAME, surname);
+        }
         map.put(OpenIdAttributesSet.EMAIL, email);
         map.put(OpenIdAttributesSet.EMAIL_VERIFIED, account.isEmailVerified());
         map.put(OpenIdAttributesSet.PREFERRED_USERNAME, username);


### PR DESCRIPTION
claims family_name is always overwritten by surname from account, even when it dows not exists, possibly deleting a valid family name attribute already existing