### PR TITLE
added saml acr assertion into auth context

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAuthenticationProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAuthenticationProvider.java
@@ -33,11 +33,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnContext;
 import org.opensaml.saml.saml2.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -254,19 +253,19 @@ public class SamlAuthenticationProvider
             return null;
         }
 
-        String acrValue = assertion
+        AuthnContext authnContext = assertion
             .getAuthnStatements()
             .stream()
             .filter(a -> a.getAuthnContext() != null)
-            .flatMap(a -> Stream.ofNullable(a.getAuthnContext().getAuthnContextClassRef()))
             .findFirst()
-            .map(acr -> acr.getURI())
+            .map(a -> a.getAuthnContext())
             .orElse(null);
 
-        if (!StringUtils.hasText(acrValue)) {
+        if (authnContext == null) {
             return null;
         }
-        return acrValue;
+
+        return authnContext.getAuthnContextClassRef().getURI();
     }
 
     @Override

--- a/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAuthenticationProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/saml/provider/SamlAuthenticationProvider.java
@@ -132,8 +132,7 @@ public class SamlAuthenticationProvider
                 attributes
             );
             if (auth.getPrincipal() instanceof DefaultSaml2AuthenticatedPrincipal) {
-                List<String> indexes =
-                    ((DefaultSaml2AuthenticatedPrincipal) auth.getPrincipal()).getSessionIndexes();
+                List<String> indexes = ((DefaultSaml2AuthenticatedPrincipal) auth.getPrincipal()).getSessionIndexes();
                 principal = new DefaultSaml2AuthenticatedPrincipal(auth.getName(), attributes, indexes);
             }
             return new Saml2Authentication(


### PR DESCRIPTION
Proposed solution to Issue #463 
ACR is extracted from Saml assertion and, if found, is included as a custom named attribute in the principal.

Example Saml contaning an ACR in an assertion below

`  0 <saml2p:Response Destination="destination-URI"`
`  1                  ID="removed"`
`  2                  InResponseTo=""`
`  3                  IssueInstant="2024-01-19T10:15:49.678Z"`
`  4                  Version="2.0"`
`  5                  xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"`
`  6                  xmlns:xs="http://www.w3.org/2001/XMLSchema"`
`  7                  >`
`  8     <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">issuer-URI</saml2:Issuer>`
`  9     <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">`
` 10         REMOVED_FOR_BREVITY`
` 11     </ds:Signature>`
` 12     <saml2p:Status xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol">`
` 13         <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />`
` 14     </saml2p:Status>`
` 15     <saml2:Assertion ID="removed"`
` 16                      IssueInstant="2024-01-19T10:15:49.621Z"`
` 17                      Version="2.0"`
` 18                      xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"`
` 19                      xmlns:xs="http://www.w3.org/2001/XMLSchema"`
` 20                      >`
` 21         <saml2:AuthnStatement AuthnInstant="2024-01-19T10:15:49.427Z"`
` 22                               SessionIndex="wPHiuUQ8oXPcl4vPiXYeL9Q_YYO6Ic1aOwkocRfo"`
` 23                               xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"`
` 24                               >`
` 25             <saml2:AuthnContext>`
` 26                 <saml2:AuthnContextClassRef xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">REQUIRED_VALUE</saml2:AuthnContextClassRef>`
` 27                 <saml2:AuthenticatingAuthority>third-party-identity-provider-URI</saml2:AuthenticatingAuthority>`
` 28             </saml2:AuthnContext>`
` 29         </saml2:AuthnStatement>`
` 30     </saml2:Assertion>`
` 31 </saml2p:Response>`
