### PR TITLE
add index to postgresql schema

### DIFF
--- a/src/main/resources/db/sql/oauth2/schema-postgresql.sql
+++ b/src/main/resources/db/sql/oauth2/schema-postgresql.sql
@@ -33,3 +33,6 @@ CREATE TABLE
         token bytea NOT NULL,
         authentication bytea NOT NULL
     );
+
+CREATE INDEX oauth_access_token_token_id_index
+    ON public.oauth_access_token (token_id);


### PR DESCRIPTION
Added ad index to a selected table in the PostgreSQL as a mitigation to issue #496.
The transaction described in the issue at isolation level serializable locks the whole table. Allegedly, adding an index will lock fewer rows, reducing the probability of the described error.