### PR TITLE
bugfix double code return

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/oauth/store/jdbc/AutoJdbcAuthorizationCodeServices.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/store/jdbc/AutoJdbcAuthorizationCodeServices.java
@@ -174,14 +174,14 @@ public class AutoJdbcAuthorizationCodeServices implements AuthorizationCodeServi
 
         if (authentication != null) {
             // remove
-            jdbcTemplate.update(deleteAuthenticationSql, code);
+            if (jdbcTemplate.update(deleteAuthenticationSql, code) > 0) {
+                long expiresAt = authentication.getSecond().longValue();
+                OAuth2Authentication oauth = authentication.getFirst();
 
-            long expiresAt = authentication.getSecond().longValue();
-            OAuth2Authentication oauth = authentication.getFirst();
-
-            // validate expire
-            if (System.currentTimeMillis() < expiresAt) {
-                return oauth;
+                // validate expire
+                if (System.currentTimeMillis() < expiresAt) {
+                    return oauth;
+                }
             }
         }
 


### PR DESCRIPTION
When removing an aouth code and returning a token, the code service might return a token even if the code deletion fails.
Changed the service to return a token only if the code service succesfully removes the code.

This is a fix for the bug described in Issue #511 