### PR TITLE
added safestring annotation

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/repository/SafeString.java
+++ b/src/main/java/it/smartcommunitylab/aac/repository/SafeString.java
@@ -1,0 +1,29 @@
+package it.smartcommunitylab.aac.repository;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = { SafeStringValidator.class })
+public @interface SafeString {
+    SafeList safelist() default SafeList.NONE;
+
+    String message() default "invalid string: value might be unsafe";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    enum SafeList {
+        NONE,
+        SIMPLE_TEXT,
+        BASIC,
+        BASIC_WITH_IMAGES,
+        RELAXED,
+    }
+}

--- a/src/main/java/it/smartcommunitylab/aac/repository/SafeString.java
+++ b/src/main/java/it/smartcommunitylab/aac/repository/SafeString.java
@@ -1,15 +1,20 @@
 package it.smartcommunitylab.aac.repository;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import javax.validation.Constraint;
 import javax.validation.Payload;
+import org.jsoup.safety.Safelist;
 
-@Target(ElementType.FIELD)
+@Documented
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
-@Constraint(validatedBy = { SafeStringValidator.class })
+@Constraint(
+    validatedBy = { SafeStringValidator.class, SafeStringCollectionValidator.class, SafeStringMapValidator.class }
+)
 public @interface SafeString {
     SafeList safelist() default SafeList.NONE;
 
@@ -19,11 +24,58 @@ public @interface SafeString {
 
     Class<? extends Payload>[] payload() default {};
 
-    enum SafeList {
-        NONE,
-        SIMPLE_TEXT,
-        BASIC,
-        BASIC_WITH_IMAGES,
-        RELAXED,
+    public enum SafeList {
+        NONE(SafeLists.NONE),
+        SIMPLE_TEXT(SafeLists.SIMPLE_TEXT),
+        BASIC(SafeLists.BASIC),
+        BASIC_WITH_IMAGES(SafeLists.BASIC_WITH_IMAGES),
+        RELAXED(SafeLists.RELAXED),
+        RELAXED_WITH_IMAGES(SafeLists.RELAXED_WITH_IMAGES);
+
+        private final Safelist value;
+
+        private SafeList(Safelist value) {
+            this.value = value;
+        }
+
+        public Safelist getValue() {
+            return value;
+        }
+    }
+
+    public static class SafeLists {
+
+        public static final Safelist NONE = Safelist.none();
+
+        public static final Safelist SIMPLE_TEXT = Safelist.simpleText();
+
+        public static final Safelist BASIC = Safelist
+            .basic()
+            .addTags("nav", "button", "hr")
+            .addProtocols("a", "href", "#")
+            .addAttributes(":all", "class")
+            .addAttributes(":all", "style")
+            .addAttributes(":all", "role");
+
+        public static final Safelist BASIC_WITH_IMAGES = BASIC
+            .addTags("img")
+            .addAttributes("img", "align", "alt", "height", "src", "title", "width")
+            .addProtocols("img", "src", "http", "https");
+
+        public static final Safelist RELAXED = Safelist
+            .relaxed()
+            .removeTags("img")
+            .addTags("nav", "button", "hr")
+            .addProtocols("a", "href", "#")
+            .addAttributes(":all", "class")
+            .addAttributes(":all", "style")
+            .addAttributes(":all", "role");
+
+        public static final Safelist RELAXED_WITH_IMAGES = RELAXED
+            .addTags("img")
+            .addAttributes("img", "align", "alt", "height", "src", "title", "width")
+            .addProtocols("img", "src", "http", "https");
+
+        private SafeLists() {}
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/repository/SafeStringCollectionValidator.java
+++ b/src/main/java/it/smartcommunitylab/aac/repository/SafeStringCollectionValidator.java
@@ -1,0 +1,26 @@
+package it.smartcommunitylab.aac.repository;
+
+import java.util.Collection;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.jsoup.safety.Cleaner;
+
+public class SafeStringCollectionValidator implements ConstraintValidator<SafeString, Collection<String>> {
+
+    private SafeString constraint;
+
+    @Override
+    public void initialize(SafeString constraint) {
+        this.constraint = constraint;
+    }
+
+    @Override
+    public boolean isValid(Collection<String> values, ConstraintValidatorContext constraintValidatorContext) {
+        if (values == null || values.isEmpty()) {
+            return true;
+        }
+
+        Cleaner cleaner = new Cleaner(constraint.safelist().getValue());
+        return values.stream().allMatch(cleaner::isValidBodyHtml);
+    }
+}

--- a/src/main/java/it/smartcommunitylab/aac/repository/SafeStringMapValidator.java
+++ b/src/main/java/it/smartcommunitylab/aac/repository/SafeStringMapValidator.java
@@ -1,0 +1,34 @@
+package it.smartcommunitylab.aac.repository;
+
+import java.util.Map;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.jsoup.safety.Cleaner;
+
+public class SafeStringMapValidator implements ConstraintValidator<SafeString, Map<?, String>> {
+
+    private SafeString constraint;
+
+    @Override
+    public void initialize(SafeString constraint) {
+        this.constraint = constraint;
+    }
+
+    @Override
+    public boolean isValid(Map<?, String> map, ConstraintValidatorContext constraintValidatorContext) {
+        if (map == null || map.isEmpty()) {
+            return true;
+        }
+
+        Cleaner cleaner = new Cleaner(constraint.safelist().getValue());
+        boolean validValues = map.values().stream().allMatch(cleaner::isValidBodyHtml);
+        boolean validKeys = map
+            .keySet()
+            .stream()
+            .filter(String.class::isInstance)
+            .map(o -> (String) o)
+            .allMatch(cleaner::isValidBodyHtml);
+
+        return validValues && validKeys;
+    }
+}

--- a/src/main/java/it/smartcommunitylab/aac/repository/SafeStringValidator.java
+++ b/src/main/java/it/smartcommunitylab/aac/repository/SafeStringValidator.java
@@ -3,16 +3,15 @@ package it.smartcommunitylab.aac.repository;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import org.jsoup.Jsoup;
-import org.jsoup.safety.Safelist;
 import org.springframework.util.StringUtils;
 
 public class SafeStringValidator implements ConstraintValidator<SafeString, String> {
 
-    private SafeString safestring;
+    private SafeString constraint;
 
     @Override
-    public void initialize(SafeString safestring) {
-        this.safestring = safestring;
+    public void initialize(SafeString constraint) {
+        this.constraint = constraint;
     }
 
     @Override
@@ -20,13 +19,7 @@ public class SafeStringValidator implements ConstraintValidator<SafeString, Stri
         if (!StringUtils.hasText(s)) {
             return true;
         }
-        return switch (safestring.safelist()) {
-            case NONE -> Jsoup.isValid(s, Safelist.none());
-            case BASIC -> Jsoup.isValid(s, Safelist.basic());
-            case RELAXED -> Jsoup.isValid(s, Safelist.relaxed());
-            case SIMPLE_TEXT -> Jsoup.isValid(s, Safelist.simpleText());
-            case BASIC_WITH_IMAGES -> Jsoup.isValid(s, Safelist.basicWithImages());
-            default -> false;
-        };
+
+        return Jsoup.isValid(s, constraint.safelist().getValue());
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/repository/SafeStringValidator.java
+++ b/src/main/java/it/smartcommunitylab/aac/repository/SafeStringValidator.java
@@ -1,0 +1,32 @@
+package it.smartcommunitylab.aac.repository;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+import org.springframework.util.StringUtils;
+
+public class SafeStringValidator implements ConstraintValidator<SafeString, String> {
+
+    private SafeString safestring;
+
+    @Override
+    public void initialize(SafeString safestring) {
+        this.safestring = safestring;
+    }
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+        if (!StringUtils.hasText(s)) {
+            return true;
+        }
+        return switch (safestring.safelist()) {
+            case NONE -> Jsoup.isValid(s, Safelist.none());
+            case BASIC -> Jsoup.isValid(s, Safelist.basic());
+            case RELAXED -> Jsoup.isValid(s, Safelist.relaxed());
+            case SIMPLE_TEXT -> Jsoup.isValid(s, Safelist.simpleText());
+            case BASIC_WITH_IMAGES -> Jsoup.isValid(s, Safelist.basicWithImages());
+            default -> false;
+        };
+    }
+}


### PR DESCRIPTION
Added an annotation reserved for security-based validation of user provided strings, as emerged from the following discussion
https://github.com/scc-digitalhub/AAC/pull/506#issuecomment-1905580717
The annotation is unused in the current pull request, but might be used for any user provided string that are rendered in a console page such as the one described in enhancement #505

Currently, the only sanitization mode supported are the ones provided by the jsoup library, but theorically more modes or flags can be defined if necessary.