### PR TITLE
simplified customization

### DIFF
--- a/src/main/resources/templates/login/button-cie.html
+++ b/src/main/resources/templates/login/button-cie.html
@@ -17,12 +17,12 @@
           th:classAppend="${authority.cssClass}"
           onclick=""
         >
-          <span class="mr-3 pr-2 border-right" aria-hidden="true">
+          <span class="mr-3 pr-2 border-right btn-login-icon" aria-hidden="true">
             <svg class="icon icon-white icon-sm">
               <use th:xlink:href="@{/svg/sprite-italia.svg#logo-cie-id}"></use>
             </svg>
           </span>
-          <span class="text-white" th:text="#{cie.login_button}"></span>
+          <span class="text-white btn-login-text" th:text="#{cie.login_button}"></span>
         </a>
       </div>
 
@@ -36,12 +36,12 @@
           th:classAppend="${authority.cssClass}"
           th:href="${entry.loginUrl}"
         >
-          <span class="mr-3 pr-2 border-right" aria-hidden="true">
+          <span class="mr-3 pr-2 border-right btn-login-icon" aria-hidden="true">
             <svg class="icon icon-white icon-sm">
               <use th:xlink:href="@{/svg/sprite-italia.svg#logo-cie-id}"></use>
             </svg>
           </span>
-          <span class="text-white" th:text="#{cie.login_button}"></span>
+          <span class="text-white btn-login-text" th:text="#{cie.login_button}"></span>
         </a>
       </div>
 
@@ -53,12 +53,12 @@
           th:classAppend="${authority.cssClass}"
           th:href="${entry.loginUrl}"
         >
-          <span class="mr-3 pr-2 border-right" aria-hidden="true">
+          <span class="mr-3 pr-2 border-right btn-login-icon" aria-hidden="true">
             <svg class="icon icon-white icon-sm">
               <use th:xlink:href="@{/svg/sprite-italia.svg#logo-cie-id}"></use>
             </svg>
           </span>
-          <span class="text-white" th:text="#{cie.login_button}"></span>
+          <span class="text-white btn-login-text" th:text="#{cie.login_button}"></span>
         </a>
       </div>
     </div>

--- a/src/main/resources/templates/login/button-expand.html
+++ b/src/main/resources/templates/login/button-expand.html
@@ -17,13 +17,13 @@
           th:classAppend="${authority.cssClass}"
           onclick=""
         >
-          <span class="mr-3 pr-2 border-right" aria-hidden="true">
+          <span class="mr-3 pr-2 border-right btn-login-icon" aria-hidden="true">
             <svg class="icon icon-black icon-sm">
               <use th:xlink:href="@{/}+${authority.iconUrl}"></use>
             </svg>
           </span>
           <span
-            class="text-black"
+            class="text-black btn-login-text"
             th:text="${authority.getTitle(#locale.language)}"
           ></span>
         </a>
@@ -39,7 +39,7 @@
           th:classAppend="${authority.cssClass}"
           th:href="${entry.loginUrl}"
         >
-          <span class="mr-3 pr-2 border-right" aria-hidden="true">
+          <span class="mr-3 pr-2 border-right btn-login-icon" aria-hidden="true">
             <svg
               th:if="${entry.iconUrl != null}"
               class="icon icon-black icon-sm"
@@ -53,7 +53,7 @@
               <use th:xlink:href="${entry.logoUrl}"></use>
             </svg>
           </span>
-          <span class="text-black" th:text="${entry.organizationName}"></span>
+          <span class="text-black btn-login-text" th:text="${entry.organizationName}"></span>
         </a>
       </div>
 
@@ -65,7 +65,7 @@
           th:classAppend="${authority.cssClass}"
           th:href="${entry.loginUrl}"
         >
-          <span class="mr-3 pr-2 border-right" aria-hidden="true">
+          <span class="mr-3 pr-2 border-right btn-login-icon" aria-hidden="true">
             <svg
               th:if="${entry.iconUrl != null}"
               class="icon icon-black icon-sm"
@@ -79,7 +79,7 @@
               <use th:xlink:href="${entry.logoUrl}"></use>
             </svg>
           </span>
-          <span class="text-black" th:text="${entry.organizationName}"></span>
+          <span class="text-black btn-login-text" th:text="${entry.organizationName}"></span>
         </a>
       </div>
     </div>

--- a/src/main/resources/templates/login/button.html
+++ b/src/main/resources/templates/login/button.html
@@ -11,12 +11,12 @@
       <p th:if="${authority.getDescription(#locale.language) != null}" th:text="${authority.getDescription(#locale.language)}"></p>
       <a class="btn btn-icon btn-outline-secondary text-left pl-3 btn-login" th:classAppend="${authority.cssClass}"
          th:href="${authority.loginUrl}">
-         <span class="mr-3 pr-2 border-right" aria-hidden="true">
+         <span class="mr-3 pr-2 border-right btn-login-icon" aria-hidden="true">
             <svg class="icon icon-black icon-sm">
                <use th:xlink:href="@{/}+${authority.iconUrl}"></use>
             </svg>
          </span>
-         <span class="text-black" th:text="${authority.getTitle(#locale.language)}"></span>
+         <span class="text-black btn-login-text" th:text="${authority.getTitle(#locale.language)}"></span>
       </a>
    </div>
 


### PR DESCRIPTION
Added custom css class value to the buttons in the login page, in particolare to the:
1. the icon/logo region of the used identity provider
2. the text/title region of the used identity provider

The two css class above are meant to simplify the button customization process through the realm css page.