### PR TITLE
Proposal for enchancement #505

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/attributes/provider/AttributeProviderSettingsMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/attributes/provider/AttributeProviderSettingsMap.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import it.smartcommunitylab.aac.SystemKeys;
 import it.smartcommunitylab.aac.base.model.AbstractSettingsMap;
 import it.smartcommunitylab.aac.model.PersistenceMode;
+import it.smartcommunitylab.aac.repository.SafeString;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
@@ -41,6 +42,8 @@ public class AttributeProviderSettingsMap extends AbstractSettingsMap {
     private Set<String> attributeSets;
     private PersistenceMode persistence;
     private String events;
+    @SafeString
+    private String notes;
 
     public Set<String> getAttributeSets() {
         return attributeSets;
@@ -66,6 +69,14 @@ public class AttributeProviderSettingsMap extends AbstractSettingsMap {
         this.events = events;
     }
 
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
     @JsonIgnore
     public void setConfiguration(AttributeProviderSettingsMap map) {
         if (map == null) {
@@ -75,6 +86,7 @@ public class AttributeProviderSettingsMap extends AbstractSettingsMap {
         this.attributeSets = map.getAttributeSets();
         this.persistence = map.getPersistence();
         this.events = map.getEvents();
+        this.notes =  map.getNotes();
     }
 
     @Override

--- a/src/main/java/it/smartcommunitylab/aac/attributes/provider/AttributeProviderSettingsMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/attributes/provider/AttributeProviderSettingsMap.java
@@ -42,6 +42,7 @@ public class AttributeProviderSettingsMap extends AbstractSettingsMap {
     private Set<String> attributeSets;
     private PersistenceMode persistence;
     private String events;
+
     @SafeString
     private String notes;
 
@@ -86,7 +87,7 @@ public class AttributeProviderSettingsMap extends AbstractSettingsMap {
         this.attributeSets = map.getAttributeSets();
         this.persistence = map.getPersistence();
         this.events = map.getEvents();
-        this.notes =  map.getNotes();
+        this.notes = map.getNotes();
     }
 
     @Override

--- a/src/main/java/it/smartcommunitylab/aac/identity/provider/IdentityProviderSettingsMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/identity/provider/IdentityProviderSettingsMap.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
+import it.smartcommunitylab.aac.repository.SafeString;
 import org.springframework.util.StringUtils;
 
 @Valid
@@ -48,6 +49,8 @@ public class IdentityProviderSettingsMap extends AbstractSettingsMap {
     private String events;
     private Integer position;
     private String template;
+    @SafeString
+    private String notes;
 
     @JsonIgnore
     private Map<String, String> hookFunctions = new HashMap<>();
@@ -90,6 +93,14 @@ public class IdentityProviderSettingsMap extends AbstractSettingsMap {
 
     public void setTemplate(String template) {
         this.template = template;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
     }
 
     public Map<String, String> getHookFunctions() {
@@ -149,8 +160,8 @@ public class IdentityProviderSettingsMap extends AbstractSettingsMap {
         this.persistence = map.getPersistence();
         this.events = map.getEvents();
         this.position = map.getPosition();
-
         this.hookFunctions = map.getHookFunctions();
+        this.notes = map.getNotes();
     }
 
     @Override

--- a/src/main/java/it/smartcommunitylab/aac/identity/provider/IdentityProviderSettingsMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/identity/provider/IdentityProviderSettingsMap.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import it.smartcommunitylab.aac.SystemKeys;
 import it.smartcommunitylab.aac.base.model.AbstractSettingsMap;
 import it.smartcommunitylab.aac.model.PersistenceMode;
+import it.smartcommunitylab.aac.repository.SafeString;
 import java.io.Serializable;
 import java.util.Base64;
 import java.util.Collections;
@@ -32,7 +33,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
-import it.smartcommunitylab.aac.repository.SafeString;
 import org.springframework.util.StringUtils;
 
 @Valid
@@ -49,6 +49,7 @@ public class IdentityProviderSettingsMap extends AbstractSettingsMap {
     private String events;
     private Integer position;
     private String template;
+
     @SafeString
     private String notes;
 

--- a/src/main/resources/public/html/provider/ap.settings.html
+++ b/src/main/resources/public/html/provider/ap.settings.html
@@ -11,6 +11,10 @@
                 <textarea rows="3" name="description" id="description" ng-model="ap.description"></textarea>
                 <label for="description" class="{{ap.description != '' ? 'active' : ''}}">Description</label>
             </div>
+            <div class="form-group col">
+                <textarea rows="3" name="description" id="notes" ng-model="ap.settings.notes"></textarea>
+                <label for="notes" class="{{ap.settings.notes != '' ? 'active' : ''}}">Notes</label>
+            </div>
             <div class="form-group col ">
                 <div class="bootstrap-select-wrapper border-bottom-0">
                     <label for="persistence">Persistence*</label>

--- a/src/main/resources/public/html/provider/idp.settings.html
+++ b/src/main/resources/public/html/provider/idp.settings.html
@@ -74,7 +74,7 @@
             <div class="form-group col ">
                 <div class="form-check">
                     <input class="form-check-input" name="linkable" id="linkable" type="checkbox"
-                           ng-model="idp.settings.linkable">
+                        ng-model="idp.settings.linkable">
                     <label for="linkable">Enable account linking</label>
                 </div>
             </div>

--- a/src/main/resources/public/html/provider/idp.settings.html
+++ b/src/main/resources/public/html/provider/idp.settings.html
@@ -35,6 +35,10 @@
                     <label for="description"
                         class="{{idp.descriptionMap[selectedLanguage] != '' ? 'active' : ''}}">Description</label>
                 </div>
+                <div class="form-group col">
+                    <textarea rows="3" name="notes" id="notes" ng-model="idp.settings.notes"></textarea>
+                    <label for="notes" class="{{idp.settings.notes != '' ? 'active' : ''}}">Notes</label>
+                </div>
 
             </div>
 
@@ -70,7 +74,7 @@
             <div class="form-group col ">
                 <div class="form-check">
                     <input class="form-check-input" name="linkable" id="linkable" type="checkbox"
-                        ng-model="idp.settings.linkable">
+                           ng-model="idp.settings.linkable">
                     <label for="linkable">Enable account linking</label>
                 </div>
             </div>

--- a/src/main/resources/public/js/realmproviders.js
+++ b/src/main/resources/public/js/realmproviders.js
@@ -788,6 +788,7 @@ angular.module('aac.controllers.realmproviders', [])
                 events: provider.settings.events,
                 position: provider.settings.position,
                 template: provider.settings.template,
+                notes: provider.settings.notes,
                 hookFunctions: hookFunctions
             }
 


### PR DESCRIPTION
Proposal for enchancement #505 
A new field reserved for internal notes was included in the settings map of identity providers and attribute providers.
The notes value is provided by the user and is used in the rendering of the given provider console page. The new safestring annotation was adopted for sanitization purposes (in that unsafe values throw an error). Proper value manipulation to a safe string will eventually be conidered in a future proposal.
