### PR TITLE
fix: changed userinfo behaviour #544

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/core/UserDetails.java
+++ b/src/main/java/it/smartcommunitylab/aac/core/UserDetails.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -96,7 +96,7 @@ public class UserDetails implements CredentialsContainer, Serializable {
         this.username = identity.getAccount().getUsername();
 
         // identity sets, at minimum we handle first login identity
-        this.identities = new HashSet<>();
+        this.identities = new LinkedHashSet<>();
         addIdentity(identity);
 
         // attributes sets (outside identities)
@@ -131,7 +131,7 @@ public class UserDetails implements CredentialsContainer, Serializable {
         this.realm = realm;
 
         // identity sets, at minimum we handle first login identity
-        this.identities = new HashSet<>();
+        this.identities = new LinkedHashSet<>();
         for (UserIdentity identity : identities) {
             addIdentity(identity);
         }

--- a/src/main/java/it/smartcommunitylab/aac/model/User.java
+++ b/src/main/java/it/smartcommunitylab/aac/model/User.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -126,7 +127,7 @@ public class User {
         // set consuming realm to source
         this.realm = source;
         this.authorities = Collections.emptySet();
-        this.identities = new HashSet<>();
+        this.identities = new LinkedHashSet<>();
         this.attributes = new ArrayList<>();
         this.realmRoles = new HashSet<>();
         this.spaceRoles = new HashSet<>();
@@ -146,7 +147,7 @@ public class User {
                 .filter(a -> (a instanceof RealmGrantedAuthority))
                 .map(a -> (RealmGrantedAuthority) a)
                 .collect(Collectors.toSet());
-        this.identities = new HashSet<>(details.getIdentities());
+        this.identities = new LinkedHashSet<>(details.getIdentities());
         this.attributes = new ArrayList<>(details.getAttributeSets(false));
         this.realmRoles = new HashSet<>();
         this.spaceRoles = new HashSet<>();
@@ -295,7 +296,7 @@ public class User {
     }
 
     public void setIdentities(Collection<UserIdentity> identities) {
-        this.identities = new HashSet<>();
+        this.identities = new LinkedHashSet<>();
         if (identities != null) {
             this.identities.addAll(identities);
             // add all attributes


### PR DESCRIPTION
Changed behaviour when extracting claims in order to satisfy a `/userinfo` request. Now claims are no longer extracted from an undefined user account, as the primary source of the claims is the "first" identity of that user, where before identity ordering was not guaranteed.
