### PR TITLE
fix: new config to support #547

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/claims/LocalGraalExecutionService.java
+++ b/src/main/java/it/smartcommunitylab/aac/claims/LocalGraalExecutionService.java
@@ -44,6 +44,7 @@ public class LocalGraalExecutionService implements ScriptExecutionService {
 
     public static final int DEFAULT_MAX_CPU_TIME = 100;
     public static final int DEFAULT_MAX_MEMORY = 10485760;
+    public static final boolean DEFAULT_REMOVE_COMMENTS = true;
 
     private int maxCpuTime;
     private int maxMemory;
@@ -53,13 +54,13 @@ public class LocalGraalExecutionService implements ScriptExecutionService {
     private final ObjectMapper mapper = new ObjectMapper()
         .registerModule(new JavaTimeModule())
         .setSerializationInclusion(Include.NON_NULL);
-    private final TypeReference<HashMap<String, Serializable>> typeRef = new TypeReference<
-        HashMap<String, Serializable>
-    >() {};
+    private final TypeReference<HashMap<String, Serializable>> typeRef =
+        new TypeReference<HashMap<String, Serializable>>() {};
 
     public LocalGraalExecutionService() {
         this.maxCpuTime = DEFAULT_MAX_CPU_TIME;
         this.maxMemory = DEFAULT_MAX_MEMORY;
+        this.removeComments = DEFAULT_REMOVE_COMMENTS;
     }
 
     public int getMaxCpuTime() {

--- a/src/main/java/it/smartcommunitylab/aac/claims/LocalGraalExecutionService.java
+++ b/src/main/java/it/smartcommunitylab/aac/claims/LocalGraalExecutionService.java
@@ -47,13 +47,15 @@ public class LocalGraalExecutionService implements ScriptExecutionService {
 
     private int maxCpuTime;
     private int maxMemory;
+    private boolean removeComments;
 
     // custom jackson configuration with typeReference
     private final ObjectMapper mapper = new ObjectMapper()
         .registerModule(new JavaTimeModule())
         .setSerializationInclusion(Include.NON_NULL);
-    private final TypeReference<HashMap<String, Serializable>> typeRef =
-        new TypeReference<HashMap<String, Serializable>>() {};
+    private final TypeReference<HashMap<String, Serializable>> typeRef = new TypeReference<
+        HashMap<String, Serializable>
+    >() {};
 
     public LocalGraalExecutionService() {
         this.maxCpuTime = DEFAULT_MAX_CPU_TIME;
@@ -74,6 +76,14 @@ public class LocalGraalExecutionService implements ScriptExecutionService {
 
     public void setMaxMemory(int maxMemory) {
         this.maxMemory = maxMemory;
+    }
+
+    public boolean isRemoveComments() {
+        return removeComments;
+    }
+
+    public void setRemoveComments(boolean removeComments) {
+        this.removeComments = removeComments;
     }
 
     // TODO implement a threadPool for sandboxes to avoid bootstrap
@@ -107,7 +117,10 @@ public class LocalGraalExecutionService implements ScriptExecutionService {
             writer.append("result = JSON.stringify(" + name + "(data));");
             writer.append("logs = JSON.stringify(_logs);");
 
-            String code = RemoveComments.perform(writer.toString());
+            String code = writer.toString();
+            if (removeComments) {
+                code = RemoveComments.perform(code);
+            }
             sandbox.eval(code);
 
             String output = (String) sandbox.get("result");
@@ -160,7 +173,10 @@ public class LocalGraalExecutionService implements ScriptExecutionService {
             writer.append("result = JSON.stringify(" + name + "(" + String.join(",", vars) + "));");
             writer.append("logs = JSON.stringify(_logs);");
 
-            String code = RemoveComments.perform(writer.toString());
+            String code = writer.toString();
+            if (removeComments) {
+                code = RemoveComments.perform(code);
+            }
             sandbox.eval(code);
 
             String output = (String) sandbox.get("result");

--- a/src/main/java/it/smartcommunitylab/aac/config/ExecutionConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/ExecutionConfig.java
@@ -17,6 +17,7 @@
 package it.smartcommunitylab.aac.config;
 
 import it.smartcommunitylab.aac.claims.LocalGraalExecutionService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -25,8 +26,21 @@ import org.springframework.core.annotation.Order;
 @Order(9)
 public class ExecutionConfig {
 
+    @Value("${engine.graal.max-cpu-time}")
+    private int graalMaxCpuTime;
+
+    @Value("${engine.graal.max-memory}")
+    private int graalMaxMemory;
+
+    @Value("${engine.graal.remove-comments}")
+    private boolean graalRemoveComments;
+
     @Bean
     public LocalGraalExecutionService localGraalExecutionService() {
-        return new LocalGraalExecutionService();
+        LocalGraalExecutionService executionService = new LocalGraalExecutionService();
+        executionService.setMaxMemory(graalMaxMemory);
+        executionService.setMaxCpuTime(graalMaxCpuTime);
+        executionService.setRemoveComments(graalRemoveComments);
+        return executionService;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -250,6 +250,12 @@ spring:
     store-type: jdbc
     jdbc.initialize-schema: always   
 
+engine:
+   graal:
+      max-cpu-time: 100
+      max-memory: 10485760
+      remove-comments: ${REMOVE_COMMENTS_IN_SCRIPTS:true}
+
 # ROLE PREFIX FOR AUTHORIZATION CHECK
 authorization:
    contextSpace:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -254,7 +254,7 @@ engine:
    graal:
       max-cpu-time: 100
       max-memory: 10485760
-      remove-comments: ${REMOVE_COMMENTS_IN_SCRIPTS:true}
+      remove-comments: ${ENGINE_GRAAL_REMOVE_COMMENTS:true}
 
 # ROLE PREFIX FOR AUTHORIZATION CHECK
 authorization:

--- a/src/test/java/it/smartcommunitylab/aac/claims/TestGraalExecutionService.java
+++ b/src/test/java/it/smartcommunitylab/aac/claims/TestGraalExecutionService.java
@@ -1,0 +1,99 @@
+package it.smartcommunitylab.aac.claims;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class TestGraalExecutionService {
+
+    /**
+     * This test checks that valid comments do not interfere with script execution
+     * when option "removeComments" is enabled (hence true)
+     * @throws Exception if either execution fails or if the result does not match expected result
+     */
+    @Test
+    public void testEnableRemoveCommentsInExecutionService() throws Exception {
+        boolean EnableRemoveCommentConfiguration = true;
+        LocalGraalExecutionService executionService = new LocalGraalExecutionService();
+        executionService.setRemoveComments(EnableRemoveCommentConfiguration);
+        Map<String, Serializable> funcInput = new HashMap<>();
+        Map<String, Serializable> expectedResult = new HashMap<>() {
+            {
+                put("key_1", "value_1");
+                put("key_2", "value_2");
+            }
+        };
+
+        String funcName = "testFunction";
+        String funcContent =
+            """
+            function testFunction(attributes) {
+                // comment before any instruction
+                attributes['key_1'] = 'value_1';
+                // comment in the middle of instructions
+                attributes['key_2'] = 'value_2';
+                // comment after last (non return) instruction
+                return attributes;
+                // comment after last instruction
+            }
+            """;
+        Map<String, Serializable> obtainedResult = new HashMap<>();
+        try {
+            obtainedResult = executionService.executeFunction(funcName, funcContent, funcInput);
+        } catch (Exception e) {
+            // ios exception, test
+            fail("test failed due to unexpected exception when running execution service", e);
+        }
+        assertThat(expectedResult.equals(obtainedResult));
+    }
+
+    /**
+     * This test checks that valid comments do not interfere with script execution
+     * when option "removeComments" is disable (hence false)
+     * @throws Exception if either execution fails or if the result does not match expected result
+     */
+    @Test
+    public void testDisableRemoveCommentsInExecutionService() throws Exception {
+        boolean DisableRemoveCommentConfiguration = true;
+        LocalGraalExecutionService executionService = new LocalGraalExecutionService();
+        executionService.setRemoveComments(DisableRemoveCommentConfiguration);
+        Map<String, Serializable> funcInput = new HashMap<>() {
+            {
+                put("http://input_key_0_with_comment.example", "value_0");
+            }
+        };
+        Map<String, Serializable> expectedResult = new HashMap<>() {
+            {
+                put("http://input_key_0_with_comment.example", "value_0");
+                put("http://key_1_with_comment.example", "value_1");
+                put("http://key_2_with_comment.example", "value_2");
+            }
+        };
+
+        String funcName = "testFunction";
+        String funcContent =
+            """
+            function testFunction(attributes) {
+                // malformed comment before any instruction '//
+                attributes['http://key_1_with_comment.example'] = 'value_1';
+                // malformed comment in the middle of instructions '//''
+                attributes['http://key_2_with_comment.example'] = 'value_2';
+                // malformed comment after last (non return) instruction ''//'
+                return attributes;
+                // malformed comment after last instruction ''//''
+            }
+            """;
+        Map<String, Serializable> obtainedResult = new HashMap<>();
+        try {
+            obtainedResult = executionService.executeFunction(funcName, funcContent, funcInput);
+        } catch (Exception e) {
+            // ios exception, test
+            fail("test failed due to unexpected exception when running execution service", e);
+        }
+        assertThat(expectedResult.equals(obtainedResult));
+    }
+}


### PR DESCRIPTION
Added new config so that it can be decided wether a comments are stripped from script (of identity providers and attribute providers) before execuition.
Default configuration is that comments are stripped from scripts (security-by-default).