### PR TITLE
added timestamp as version to custom idp from app.yml

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/identity/service/IdentityProviderService.java
+++ b/src/main/java/it/smartcommunitylab/aac/identity/service/IdentityProviderService.java
@@ -148,6 +148,10 @@ public class IdentityProviderService
                     cip.setSettings(settings.getConfiguration());
                     cip.setConfiguration(configuration);
 
+                    // add temporary version as it might be required by jdbc repository persistence
+                    int registeredVersion = (int) (System.currentTimeMillis() / (60*1000)); // current time in minutes
+                    cip.setVersion(registeredVersion);
+
                     // register
                     systemProviders.put(providerId, cip);
                 } catch (

--- a/src/main/java/it/smartcommunitylab/aac/identity/service/IdentityProviderService.java
+++ b/src/main/java/it/smartcommunitylab/aac/identity/service/IdentityProviderService.java
@@ -148,9 +148,13 @@ public class IdentityProviderService
                     cip.setSettings(settings.getConfiguration());
                     cip.setConfiguration(configuration);
 
-                    // add temporary version as it might be required by jdbc repository persistence
-                    int registeredVersion = (int) (System.currentTimeMillis() / (60*1000)); // current time in minutes
-                    cip.setVersion(registeredVersion);
+                    // add version as it might be required by jdbc repository persistence
+                    if (cp.getVersion() == null) {
+                        int registeredVersion = (int) (System.currentTimeMillis() / (60 * 1000)); // current time in minutes
+                        cip.setVersion(registeredVersion);
+                    } else {
+                        cip.setVersion(cp.getVersion());
+                    }
 
                     // register
                     systemProviders.put(providerId, cip);


### PR DESCRIPTION
Temporary solution to issue #551 
Added current timestamp as version for configurable identity provider fior usage with configuration `persistence.repository.providerConfig=jdbc` .
Note that this workaround techically conflict with the design choice of having immutable providers defined in the config file. The providers are _still_ intended to be immutable.