### PR TITLE
feat: add support for configurations with separate pools for different databases (#581)

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/config/AuditConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/AuditConfig.java
@@ -31,6 +31,7 @@ import it.smartcommunitylab.aac.jose.JWKSetKeyStore;
 import it.smartcommunitylab.aac.oauth.event.OAuth2EventPublisher;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -51,6 +52,7 @@ import org.springframework.util.StringUtils;
 public class AuditConfig {
 
     @Autowired
+    @Qualifier("jdbcAuditDataSource")
     private DataSource dataSource;
 
     @Value("${audit.issuer}")

--- a/src/main/java/it/smartcommunitylab/aac/config/DatabaseConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/DatabaseConfig.java
@@ -105,6 +105,21 @@ public class DatabaseConfig {
         return new HikariDataSource(config);
     }
 
+    @Bean(name = "jdbcAuditDataSource")
+    public DataSource jdbcAuditDataSource(@Qualifier("auditJdbcProperties") JdbcProperties properties,
+        @Qualifier("jdbcDataSource") DataSource jdbcDataSource, @Qualifier("jdbcProperties") JdbcProperties jdbcProperties)
+            throws PropertyVetoException {
+
+        if(!properties.equals(jdbcProperties)){
+
+            HikariConfig config = buildDataSourceConfig(properties);
+            config.setPoolName("jdbcAuditConnectionPool");
+            return new HikariDataSource(config);
+        }
+
+        return jdbcDataSource;
+    }
+
     @Primary
     @Bean(name = "jpaDataSource")
     public HikariDataSource jpaDataSource(@Qualifier("jdbcProperties") JdbcProperties properties)
@@ -177,7 +192,7 @@ public class DatabaseConfig {
     @Bean(name = "coreJdbcDataSourceInitializer")
     public JdbcDataSourceInitializer jdbcDataSourceInitializer(
         @Qualifier("jdbcDataSource") DataSource dataSource,
-        JdbcProperties properties
+        @Qualifier("jdbcProperties") JdbcProperties properties
     ) {
         return new JdbcDataSourceInitializer(dataSource, properties);
     }
@@ -185,7 +200,7 @@ public class DatabaseConfig {
     @Bean(name = "oauth2JdbcDataSourceInitializer")
     public JdbcDataSourceInitializer oauth2DataSourceInitializer(
         @Qualifier("jdbcDataSource") DataSource dataSource,
-        JdbcProperties properties
+        @Qualifier("jdbcProperties") JdbcProperties properties
     ) {
         return new JdbcDataSourceInitializer(dataSource, properties, "classpath:db/sql/oauth2/schema-@@platform@@.sql");
     }
@@ -193,8 +208,8 @@ public class DatabaseConfig {
     //TODO add optional ObjectProvider<DataSource> to support separated dataSource for audit
     @Bean(name = "auditJdbcDataSourceInitializer")
     public JdbcDataSourceInitializer auditDataSourceInitializer(
-        @Qualifier("jdbcDataSource") DataSource dataSource,
-        JdbcProperties properties
+        @Qualifier("jdbcAuditDataSource") DataSource dataSource,
+        @Qualifier("auditJdbcProperties") JdbcProperties properties
     ) {
         return new JdbcDataSourceInitializer(dataSource, properties, "classpath:db/sql/audit/schema-@@platform@@.sql");
     }

--- a/src/main/java/it/smartcommunitylab/aac/config/JdbcProperties.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/JdbcProperties.java
@@ -17,6 +17,8 @@
 package it.smartcommunitylab.aac.config;
 
 import java.util.Map;
+import java.util.Objects;
+
 import org.springframework.boot.sql.init.DatabaseInitializationMode;
 
 public class JdbcProperties {
@@ -27,6 +29,7 @@ public class JdbcProperties {
     private String platform;
     private String schema = DEFAULT_SCHEMA_LOCATION;
 
+    // TODO to implement EQUALS with differ from ALL fields FROM here
     private String driver;
     private String dialect;
     private String url;
@@ -167,5 +170,32 @@ public class JdbcProperties {
 
     public void setDataSourceProperties(Map<String, Object> dataSourceProperties) {
         this.dataSourceProperties = dataSourceProperties;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        JdbcProperties that = (JdbcProperties) obj;
+        return showSql == that.showSql &&
+                maxPoolSize == that.maxPoolSize &&
+                minPoolSize == that.minPoolSize &&
+                idleTimeout == that.idleTimeout &&
+                keepAliveTimeout == that.keepAliveTimeout &&
+                connectionTimeout == that.connectionTimeout &&
+                Objects.equals(driver, that.driver) &&
+                Objects.equals(dialect, that.dialect) &&
+                Objects.equals(url, that.url) &&
+                Objects.equals(user, that.user) &&
+                Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(driver, dialect, url, user, password, showSql, maxPoolSize, minPoolSize, idleTimeout, keepAliveTimeout, connectionTimeout);
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/config/PropertiesConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/PropertiesConfig.java
@@ -37,6 +37,12 @@ public class PropertiesConfig {
         return new JdbcProperties();
     }
 
+    @Bean(name = "auditJdbcProperties")
+    @ConfigurationProperties(prefix = "audit.jdbc")
+    public JdbcProperties jdbcAuditProps() {
+        return new JdbcProperties();
+    }
+
     @Bean
     @ConfigurationProperties(prefix = "authorities.identity")
     public IdentityAuthoritiesProperties identityAuthoritiesProps() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,6 +108,20 @@ audit:
    kid:
       sig: ${AUDIT_KID_SIG:}         
       enc: ${AUDIT_KID_ENC:}
+   jdbc:
+     dialect: ${AUDIT_JDBC_DIALECT:${jdbc.dialect}}
+     driver: ${AUDIT_JDBC_DRIVER:${jdbc.driver}}
+     url: ${AUDIT_JDBC_URL:${jdbc.url}}
+     user: ${AUDIT_JDBC_USER:${jdbc.user}}
+     password: ${AUDIT_JDBC_PASS:${jdbc.password}}
+     show-sql: false
+     initialize-schema: always
+     max-pool-size: ${AUDIT_JDBC_MAX_POOL_SIZE:${jdbc.maxpoolsize}}
+     min-pool-size: ${AUDIT_JDBC_MIN_POOL_SIZE:${jdbc.minpoolsize}}
+     idle-timeout: ${AUDIT_JDBC_IDLE_TIMEOUT:${jdbc.idletimeout}}
+     keep-alive-timeout: ${AUDIT_JDBC_KEEP_ALIVE_TIMEOUT:${jdbc.keepalivetimeout}}
+     connection-timeout: ${AUDIT_JDBC_CONNECTION_TIMEOUT:${jdbc.connectiontimeout}}
+     data-source-properties: {}
 
 #EXTERNAL PROVIDERS
 authorities:


### PR DESCRIPTION
- Added the ability to configure a separate pool for the AUDIT database.
- If not specified, the default pool of AAC will be used.