### PR TITLE
feat: config openidfed metadata extension

### DIFF
--- a/dev-console/src/i18n/en/fields.json
+++ b/dev-console/src/i18n/en/fields.json
@@ -514,6 +514,18 @@
         "name": "Contacts",
         "helperText": ""
     },
+    "logoUri": {
+        "name": "(Optional) Logo URI",
+        "helperText": ""
+    },
+    "policyUri": {
+        "name": "(Optional) Policy URI",
+        "helperText": ""
+    },
+    "homepageUri": {
+        "name": "(Optional) Homepage Uri",
+        "helperText": ""
+    },
     "trustAnchor": {
         "name": "Trust Anchors",
         "helperText": ""

--- a/dev-console/src/idps/schemas.ts
+++ b/dev-console/src/idps/schemas.ts
@@ -221,6 +221,10 @@ export const uiSchemaOpenidfedIdp: UiSchema = {
 
         'organizationName',
         'contacts',
+        'logoUri',
+        'policyUri',
+        'homepageUri',
+      
         'trustAnchor',
         'providers',
         'authorityHints',

--- a/src/main/java/it/smartcommunitylab/aac/openidfed/provider/OpenIdFedIdentityProviderConfigMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/openidfed/provider/OpenIdFedIdentityProviderConfigMap.java
@@ -82,6 +82,9 @@ public class OpenIdFedIdentityProviderConfigMap extends AbstractConfigMap {
 
     private String organizationName;
     private List<String> contacts;
+    private String logoUri;
+    private String policyUri;
+    private String homepageUri;
 
     public String getClientId() {
         return clientId;
@@ -259,6 +262,30 @@ public class OpenIdFedIdentityProviderConfigMap extends AbstractConfigMap {
         this.contacts = contacts;
     }
 
+    public String getLogoUri() {
+        return logoUri;
+    }
+
+    public void setLogoUri(String logoUri) {
+        this.logoUri = logoUri;
+    }
+
+    public String getPolicyUri() {
+        return policyUri;
+    }
+
+    public void setPolicyUri(String policyUri) {
+        this.policyUri = policyUri;
+    }
+
+    public String getHomepageUri() {
+        return homepageUri;
+    }
+
+    public void setHomepageUri(String homepageUri) {
+        this.homepageUri = homepageUri;
+    }
+
     @JsonIgnore
     public void setConfiguration(final OpenIdFedIdentityProviderConfigMap map) {
         this.clientId = map.getClientId();
@@ -289,6 +316,9 @@ public class OpenIdFedIdentityProviderConfigMap extends AbstractConfigMap {
 
         this.organizationName = map.getOrganizationName();
         this.contacts = map.getContacts();
+        this.logoUri = map.getLogoUri();
+        this.policyUri = map.getPolicyUri();
+        this.homepageUri = map.getHomepageUri();
     }
 
     @Override

--- a/src/main/resources/public/html/provider/idp.conf.openidfed.html
+++ b/src/main/resources/public/html/provider/idp.conf.openidfed.html
@@ -61,7 +61,22 @@
                 <tags-input name="contacts" type="text" placeholder="contacts" ng-model="openidfedContacts">
                 </tags-input>
             </div>
-        </div>   
+        </div>
+        <div class="form-group col ">
+            <label for="logoUri">Logo URI</label>
+            <input type="text" name="logoUri" class="form-control form-control-sm" id="logoUri"
+                   ng-model="idp.configuration.logoUri">
+        </div>
+        <div class="form-group col ">
+            <label for="policyUri">Policy URI</label>
+            <input type="text" name="policyUri" class="form-control form-control-sm" id="policyUri"
+                   ng-model="idp.configuration.policyUri">
+        </div>
+        <div class="form-group col ">
+            <label for="homepageUri">Homepage URI</label>
+            <input type="text" name="homepageUri" class="form-control form-control-sm" id="homepageUri"
+                   ng-model="idp.configuration.homepageUri">
+        </div>
         <div class="form-group col ">
             <label for="trustAnchor">Trust Anchor*</label>
             <input type="text" required name="trustAnchor" class="form-control form-control-sm" id="trustAnchor"


### PR DESCRIPTION
This pull request closes #602

Added configuration for openid federation metadata extensions `logo_uri`, `policy_uri`, `homepage_uri`.
The parameters are optionals. When not set, the previuous parameters resolution logic is used.
This is done to preserve backward compatibility.

@matteo-s this is my first PR in a while and I'm not fully aware of all previous changes. Please double (or triple) check that nothing silly was done.